### PR TITLE
Fix optionally hanging CATransaction

### DIFF
--- a/RouteComposer/Classes/Adapters/NavigationControllerAdapter.swift
+++ b/RouteComposer/Classes/Adapters/NavigationControllerAdapter.swift
@@ -43,24 +43,36 @@ public struct NavigationControllerAdapter<VC: UINavigationController>: ConcreteC
             completion(.failure(RoutingError.compositionFailed(.init("\(String(describing: navigationController)) does not contain \(String(describing: viewController))"))))
             return
         }
-        CATransaction.begin()
+        if animated {
+            CATransaction.begin()
+            CATransaction.setCompletionBlock {
+                completion(.success)
+            }
+        }
         navigationController.popToViewController(viewController, animated: animated)
-        CATransaction.setCompletionBlock {
+        if animated {
+            CATransaction.commit()
+        } else {
             completion(.success)
         }
-        CATransaction.commit()
     }
 
     public func setContainedViewControllers(_ containedViewControllers: [UIViewController], animated: Bool, completion: @escaping (_: RoutingResult) -> Void) {
         guard let navigationController = navigationController else {
             return completion(.failure(RoutingError.compositionFailed(.init("\(String(describing: VC.self)) has been deallocated"))))
         }
-        CATransaction.begin()
+        if animated {
+            CATransaction.begin()
+            CATransaction.setCompletionBlock {
+                completion(.success)
+            }
+        }
         navigationController.setViewControllers(containedViewControllers, animated: animated)
-        CATransaction.setCompletionBlock {
+        if animated {
+            CATransaction.commit()
+        } else {
             completion(.success)
         }
-        CATransaction.commit()
     }
 
 }


### PR DESCRIPTION
part of the navigation process might be not animated. In this case, the CATransaction should not be registered as the invoker of the completion block because there will be no animation.