### PR TITLE
Use UIViewController's transitionCoordinator for animated completion block

### DIFF
--- a/RouteComposer/Classes/Adapters/NavigationControllerAdapter.swift
+++ b/RouteComposer/Classes/Adapters/NavigationControllerAdapter.swift
@@ -48,15 +48,11 @@ public struct NavigationControllerAdapter<VC: UINavigationController>: ConcreteC
             completion(.failure(RoutingError.compositionFailed(.init("\(String(describing: navigationController)) does not contain \(String(describing: viewController))"))))
             return
         }
-        if animated {
-            CATransaction.begin()
-            CATransaction.setCompletionBlock {
-                completion(.success)
-            }
-        }
         navigationController.popToViewController(viewController, animated: animated)
         if animated {
-            CATransaction.commit()
+            navigationController.transitionCoordinator?.animate(alongsideTransition: nil) { _ in
+                completion(.success)
+            }
         } else {
             completion(.success)
         }
@@ -66,15 +62,11 @@ public struct NavigationControllerAdapter<VC: UINavigationController>: ConcreteC
         guard let navigationController = navigationController else {
             return completion(.failure(RoutingError.compositionFailed(.init("\(String(describing: VC.self)) has been deallocated"))))
         }
-        if animated {
-            CATransaction.begin()
-            CATransaction.setCompletionBlock {
-                completion(.success)
-            }
-        }
         navigationController.setViewControllers(containedViewControllers, animated: animated)
         if animated {
-            CATransaction.commit()
+            navigationController.transitionCoordinator?.animate(alongsideTransition: nil) { _ in
+                completion(.success)
+            }
         } else {
             completion(.success)
         }

--- a/RouteComposer/Classes/Adapters/NavigationControllerAdapter.swift
+++ b/RouteComposer/Classes/Adapters/NavigationControllerAdapter.swift
@@ -49,8 +49,8 @@ public struct NavigationControllerAdapter<VC: UINavigationController>: ConcreteC
             return
         }
         navigationController.popToViewController(viewController, animated: animated)
-        if animated {
-            navigationController.transitionCoordinator?.animate(alongsideTransition: nil) { _ in
+        if let transitionCoordinator = navigationController.transitionCoordinator, animated {
+            transitionCoordinator.animate(alongsideTransition: nil) { _ in
                 completion(.success)
             }
         } else {
@@ -63,8 +63,8 @@ public struct NavigationControllerAdapter<VC: UINavigationController>: ConcreteC
             return completion(.failure(RoutingError.compositionFailed(.init("\(String(describing: VC.self)) has been deallocated"))))
         }
         navigationController.setViewControllers(containedViewControllers, animated: animated)
-        if animated {
-            navigationController.transitionCoordinator?.animate(alongsideTransition: nil) { _ in
+        if let transitionCoordinator = navigationController.transitionCoordinator, animated {
+            transitionCoordinator.animate(alongsideTransition: nil) { _ in
                 completion(.success)
             }
         } else {


### PR DESCRIPTION
NavigationControllerAdapter is using CATransaction for registering a completion block in navigation events that are animated.
Apparently (and in live tests) - the completion block isn't always called when using this method, see also [this stack overflow discussion](https://stackoverflow.com/questions/12904410/completion-block-for-popviewcontroller).

Using the transition coordinator in this specific case is more reliable (no missed completion blocks in animated transitions), and according to Apple documentation, a transition coordinator will always be available during the a transition.